### PR TITLE
Add cross-platform CI and migrate example to polyscope

### DIFF
--- a/.github/workflows/continuous.yaml
+++ b/.github/workflows/continuous.yaml
@@ -1,0 +1,61 @@
+name: Build
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  CTEST_OUTPUT_ON_FAILURE: ON
+  CTEST_PARALLEL_LEVEL: 1
+
+jobs:
+  build:
+    name: ${{ matrix.os }} (${{ matrix.config }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-24.04, macos-15, windows-2025]
+        config: [Release, Debug]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Ninja
+        uses: seanmiddleditch/gha-setup-ninja@master
+
+      - name: Dependencies (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y xorg-dev
+
+      - name: Ccache
+        if: runner.os != 'Windows'
+        uses: hendrikmuhs/ccache-action@v1.2
+        with:
+          key: ${{ matrix.os }}-${{ matrix.config }}
+
+      - name: Setup MSVC environment (Windows)
+        if: runner.os == 'Windows'
+        uses: ilammy/msvc-dev-cmd@v1
+
+      - name: Configure
+        run: |
+          cmake --version
+          cmake -B build -S . -G Ninja -DCMAKE_BUILD_TYPE=${{ matrix.config }}
+
+      - name: Build
+        run: cmake --build build
+
+      - name: Tests
+        run: ctest --test-dir build --verbose

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,8 +23,8 @@ list(PREPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
 # Include the Lagrange library (only importing lagrange::core for now)
 include(lagrange) # Note: Lagrange's version in `cmake/lagrange.cmake` might be old, update if needed.
 
-# Import additional Lagrange modules lagrange::ui and lagrange::io
-lagrange_include_modules(ui io)
+# Import additional Lagrange modules lagrange::io and lagrange::polyscope
+lagrange_include_modules(io polyscope)
 
 # We can also include dependencies from Lagrange's .cmake files
 FetchContent_GetProperties(lagrange)

--- a/app/CMakeLists.txt
+++ b/app/CMakeLists.txt
@@ -14,6 +14,7 @@ file(GLOB APP_SOURCES "*.h" "*.cpp")
 add_executable(foo_app ${APP_SOURCES})
 target_link_libraries(foo_app PUBLIC
     foo::lib
-    lagrange::ui
+    lagrange::polyscope
+    lagrange::io
     CLI11::CLI11
 )

--- a/app/main.cpp
+++ b/app/main.cpp
@@ -6,73 +6,122 @@
  * accordance with the terms of the Adobe license agreement accompanying
  * it.
  */
-// If possible, move your code to your library, so that it can be re-used more easily
-// and you are sure to avoid UI or other application-specific dependencies.
-// Basically, create your library, and be your own client.
-#include <foo/foo.h>
-
-// Third-party include
-#include <lagrange/Mesh.h>
-#include <lagrange/create_mesh.h>
+#include <lagrange/find_matching_attributes.h>
 #include <lagrange/io/load_mesh.h>
-#include <lagrange/ui/UI.h>
+#include <lagrange/io/load_simple_scene.h>
+#include <lagrange/io/save_mesh.h>
+#include <lagrange/map_attribute.h>
+#include <lagrange/polyscope/register_structure.h>
+#include <lagrange/scene/simple_scene_convert.h>
+#include <lagrange/unify_index_buffer.h>
+#include <lagrange/views.h>
+
+
+// clang-format off
+#include <lagrange/utils/warnoff.h>
+#include <polyscope/polyscope.h>
+#include <lagrange/utils/warnon.h>
+#include <lagrange/utils/fmt/format.h>
+#include <lagrange/utils/fmt/join.h>
+// clang-format on
+
 #include <CLI/CLI.hpp>
 
-// System include
-#include <iostream>
+using Scalar = double;
+using Index = uint32_t;
+using SurfaceMesh = lagrange::SurfaceMesh<Scalar, Index>;
+using SimpleScene = lagrange::scene::SimpleScene<Scalar, Index, 3>;
 
-namespace ui = lagrange::ui;
+void prepare_mesh(SurfaceMesh& mesh)
+{
+    lagrange::AttributeMatcher matcher;
+    matcher.element_types = lagrange::AttributeElement::Indexed;
 
-int main(int argc, char const* argv[])
+    // 1st, unify index buffers for all non-UV indexed attributes
+    matcher.usages = ~lagrange::BitField(lagrange::AttributeUsage::UV);
+    auto ids = lagrange::find_matching_attributes(mesh, matcher);
+    if (!ids.empty()) {
+        std::vector<std::string> attr_names;
+        for (auto id : ids) {
+            attr_names.emplace_back(mesh.get_attribute_name(id));
+        }
+        lagrange::logger().info(
+            "Unifying index buffers for {} non-UV indexed attributes: {}",
+            ids.size(),
+            lagrange::join(attr_names, ", "));
+        mesh = lagrange::unify_index_buffer(mesh, ids);
+    }
+
+    // 2nd, convert indexed UV attributes into corner attributes
+    matcher.usages = lagrange::AttributeUsage::UV;
+    ids = lagrange::find_matching_attributes(mesh, matcher);
+    for (auto id : ids) {
+        lagrange::logger().info(
+            "Converting indexed UV attribute to corner attribute: {}",
+            mesh.get_attribute_name(id));
+        map_attribute_in_place(mesh, id, lagrange::AttributeElement::Corner);
+    }
+}
+
+int main(int argc, char** argv)
 {
     struct
     {
-        std::string input;
+        std::vector<lagrange::fs::path> inputs;
+        bool scene = false;
+        int log_level = 2; // normal
     } args;
 
     CLI::App app{argv[0]};
-    app.option_defaults()->always_capture_default();
-    app.add_option("input", args.input, "Input mesh.");
-    CLI11_PARSE(app, argc, argv);
+    app.add_option("inputs", args.inputs, "Input mesh(es).")->required()->check(CLI::ExistingFile);
+    app.add_option("-l,--level", args.log_level, "Log level (0 = most verbose, 6 = off).");
+    app.add_flag("--scene", args.scene, "Load as a scene (instead of a single mesh per file).");
+    CLI11_PARSE(app, argc, argv)
 
-    std::cout << "Hello world!" << std::endl;
+    spdlog::set_level(static_cast<spdlog::level::level_enum>(args.log_level));
 
-    ui::Viewer viewer("Hello world!", 800, 600);
-    if (!viewer.is_initialized()) return 1;
-
-    auto& r = viewer.registry();
-
-    ui::Entity mesh_entity = ui::NullEntity;
-
-    if (args.input.empty()) {
-        // you can create meshes and import in UI
-        std::shared_ptr<lagrange::TriangleMesh3D> mesh = lagrange::create_sphere();
-        mesh_entity = ui::register_mesh(r, mesh);
-
-    } else if (true) {
-        // you can load meshes and load into the UI. This will only load geometry, and discard
-        // things like material information.
-        std::shared_ptr<lagrange::TriangleMesh3D> mesh =
-            lagrange::io::load_mesh<lagrange::TriangleMesh3D>(args.input);
-        mesh_entity = ui::register_mesh(r, mesh);
-
-    } else {
-        // or you can use the ui loader
-        mesh_entity = ui::load_obj<lagrange::TriangleMesh3D>(r, args.input);
-        // if you have LAGRANGE_WITH_ASSIMP enabled, you can also use ui::load_scene
+    // Set Z-up for .obj and .fbx files
+    if (std::all_of(args.inputs.begin(), args.inputs.end(), [](const lagrange::fs::path& p) {
+            auto ext = p.extension();
+            return ext == ".obj" || ext == ".fbx";
+        })) {
+        polyscope::view::setUpDir(polyscope::UpDir::ZUp);
+        polyscope::view::setFrontDir(polyscope::FrontDir::NegYFront);
     }
 
-    // Add mesh to the scene
-    ui::show_mesh(r, mesh_entity);
+    polyscope::options::configureImGuiStyleCallback = []() {
+        ImGui::Spectrum::StyleColorsSpectrum();
+        ImGui::Spectrum::LoadFont();
+    };
+    polyscope::init();
 
-    // Adjust camera to show the entire mesh, regardless of it's original size
-    ui::camera_focus_and_fit(r, ui::get_focused_camera_entity(r));
+    lagrange::io::LoadOptions load_options;
+    load_options.stitch_vertices = true;
 
-    viewer.run([](ui::Registry& r) -> bool {
-        // main loop code
+    for (auto input : args.inputs) {
+        lagrange::logger().info("Loading input: {}", input.string());
 
-        return true; // should continue running?
-    });
+        if (args.scene) {
+            SimpleScene simple_scene =
+                lagrange::io::load_simple_scene<SimpleScene>(input, load_options);
+            auto meshes = lagrange::scene::simple_scene_to_meshes(simple_scene);
+            lagrange::logger().info(
+                "Loaded scene with {} mesh(es) from {}",
+                meshes.size(),
+                input.string());
+            for (size_t i = 0; i < meshes.size(); ++i) {
+                prepare_mesh(meshes[i]);
+                std::string name = input.stem().string() + "_" + std::to_string(i);
+                lagrange::polyscope::register_structure(name, std::move(meshes[i]));
+            }
+        } else {
+            SurfaceMesh mesh = lagrange::io::load_mesh<SurfaceMesh>(input, load_options);
+            prepare_mesh(mesh);
+            lagrange::polyscope::register_structure(input.stem().string(), std::move(mesh));
+        }
+    }
+
+    polyscope::show();
 
     return 0;
 }

--- a/src/foo.cpp
+++ b/src/foo.cpp
@@ -8,12 +8,13 @@
  */
 #include <foo/foo.h>
 
-#include <lagrange/Mesh.h>
+#include <lagrange/SurfaceMesh.h>
 
 namespace foo {
 
 int foo_add(int a, int b)
 {
+    lagrange::SurfaceMesh32f mesh;
     return a + b;
 }
 


### PR DESCRIPTION
## Summary

- Add a simplified cross-platform CI workflow (`.github/workflows/continuous.yaml`) building + testing on Linux, macOS, and Windows across Release/Debug, adapted from `adobe/lagrange` but stripped down for this example project.
- Migrate the demo app from `lagrange::ui` to `lagrange::polyscope` and update the library to the `SurfaceMesh` API, matching `lagrange-cpp-project`.

## Changes

| File | Change |
|---|---|
| `.github/workflows/continuous.yaml` | New CI: matrix over `ubuntu-24.04` / `macos-15` / `windows-2025` × Release/Debug; Ninja, ccache (Unix), MSVC env (Windows), `xorg-dev` (Linux). |
| `CMakeLists.txt` | `lagrange_include_modules(ui io)` -> `(io polyscope)` |
| `app/CMakeLists.txt` | `lagrange::ui` -> `lagrange::polyscope` + `lagrange::io` |
| `app/main.cpp` | Rewrite from the ui viewer to the polyscope API (mesh prep, scene loading, CLI flags) |
| `src/foo.cpp` | `lagrange/Mesh.h` -> `lagrange/SurfaceMesh.h` |

Existing MIT/Adobe license headers are preserved on all files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)